### PR TITLE
Resolve "#42 Usage instructions are printed with add and release commands"

### DIFF
--- a/changelogs/unreleased/42-fix-usage-instructions_1.json
+++ b/changelogs/unreleased/42-fix-usage-instructions_1.json
@@ -1,0 +1,5 @@
+{
+    "message": "Fix usage instructions printed with add and release commands",
+    "type": "Fixed",
+    "issue": "42"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ async function main() {
         ? process.argv
         : process.argv.concat(options.config.defaultCommand);
 
-    const args = await program.parseAsync(argv);
+    const { args } = await program.parseAsync(argv);
 
     if (!args.length) {
         program.outputHelp();


### PR DESCRIPTION
Due to commander package upgrade in last pull request, the return value of parseAsync function had changed and has not been handled.